### PR TITLE
Add variant column to history table

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -417,6 +417,7 @@ class mod_topomojo_renderer extends \plugin_renderer_base {
         if ($showuser) {
             $data->tableheaders->username = get_string('username', 'mod_topomojo');
             $data->tableheaders->eventguid = get_string('eventid', 'mod_topomojo');
+            $data->tableheaders->variant = get_string('variant', 'mod_topomojo');
         }
         if ($showdetail) {
             $data->tableheaders->name = get_string('workspace', 'mod_topomojo');
@@ -437,6 +438,7 @@ class mod_topomojo_renderer extends \plugin_renderer_base {
                     $user = $DB->get_record("user", ['id' => $attempt->userid]);
                     $rowdata->username = fullname($user);
                     $rowdata->eventguid = $attempt->eventid ?: "-";
+                    $rowdata->variant = $attempt->variant ?? "-";
                 }
                 if ($showdetail) {
                     $topomojo = $DB->get_record("topomojo", ['id' => $attempt->topomojoid]);

--- a/templates/history.mustache
+++ b/templates/history.mustache
@@ -59,6 +59,9 @@ DM24-1175
                     {{#eventguid}}
                         <th>{{eventguid}}</th>
                     {{/eventguid}}
+                    {{#variant}}
+                        <th>{{variant}}</th>
+                    {{/variant}}
                     {{#name}}
                         <th>{{name}}</th>
                     {{/name}}
@@ -78,6 +81,9 @@ DM24-1175
                     {{#eventguid}}
                         <td>{{eventguid}}</td>
                     {{/eventguid}}
+                    {{#variant}}
+                        <td>{{variant}}</td>
+                    {{/variant}}
                     {{#moduleurl}}
                         <td><a href="{{moduleurl}}">{{name}}</a></td>
                     {{/moduleurl}}

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026052900;
+$plugin->version = 2026052901;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;


### PR DESCRIPTION
Display the assigned variant number in the attempts history table to verify random variant distribution is working correctly.