### PR TITLE
Handle variants with no questions gracefully

### DIFF
--- a/classes/topomojo_attempt.php
+++ b/classes/topomojo_attempt.php
@@ -107,9 +107,18 @@ class topomojo_attempt {
 
                 // Pass variant to add_questions_to_quba so it only loads matching questions
                 $attemptlayout = $this->questionmanager->add_questions_to_quba($this->quba, $variant);
-                // Add the attempt layout to this instance
+
+                // Add the attempt layout to this instance (may be empty if variant has no questions)
                 $this->attempt->layout = implode(',', $attemptlayout);
-                \question_engine::save_questions_usage_by_activity($this->quba);
+
+                // Only save QUBA if questions were added
+                if (!empty($attemptlayout)) {
+                    \question_engine::save_questions_usage_by_activity($this->quba);
+                } else {
+                    debugging("Variant $variant has no questions - QUBA created but empty", DEBUG_DEVELOPER);
+                    // Don't save empty QUBA - it will cause errors when trying to render
+                    $this->quba = null;
+                }
             }
         } else { // else load it up in this class instance
             debugging("loading existing attempt with variant=" . ($dbattempt->variant ?? 'null'), DEBUG_DEVELOPER);
@@ -317,6 +326,11 @@ class topomojo_attempt {
      * @return string the HTML fragment for the question
      */
     public function render_question($slotid, $review = false, $reviewoptions = '', $when = null) {
+        // Return empty string if no QUBA (variant has no questions)
+        if (!$this->quba) {
+            return '';
+        }
+
         $displayoptions = $this->get_display_options($review, $reviewoptions, $when);
         $questionnum = $this->get_question_number(); // set to 1 if it doesnt exist
         $this->add_question_number(); // increment qnum

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026052900;
+$plugin->version = 2026060100;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;
@@ -64,4 +64,4 @@ $plugin->dependencies = [
 $plugin->maturity = MATURITY_BETA;
 
 // This is the named version.
-$plugin->release = '1.0.4';
+$plugin->release = '1.0.5';


### PR DESCRIPTION
Allow attempts to be created for variants that have no questions (either from TopoMojo or manually added). Instead of creating an empty QUBA that breaks on render, skip QUBA creation and return empty string when trying to render questions. This allows the gamespace to run normally even when the variant has no questions to answer.