### PR TITLE
Fix/expired cleanup operator

### DIFF
--- a/classes/task/cleanup_gamespaces.php
+++ b/classes/task/cleanup_gamespaces.php
@@ -36,8 +36,9 @@ class cleanup_gamespaces extends \core\task\scheduled_task {
         $cleaned = 0;
 
         // Find finished/abandoned attempts with active gamespaces
+        // State column is char(16) so values must be strings for PostgreSQL.
         list($insql, $inparams) = $DB->get_in_or_equal(
-            [\mod_topomojo\topomojo_attempt::ABANDONED, \mod_topomojo\topomojo_attempt::FINISHED],
+            [(string)\mod_topomojo\topomojo_attempt::ABANDONED, (string)\mod_topomojo\topomojo_attempt::FINISHED],
             SQL_PARAMS_NAMED,
             'state'
         );

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026052901;
+$plugin->version = 2026060200;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;


### PR DESCRIPTION
Error in Moodle
```
Execute scheduled task: Clean up expired TopoMojo gamespaces (mod_topomojo\task\cleanup_gamespaces)
... started 22:22:31. Current memory use 7.0 MB.
Debugging increased temporarily due to faildelay of 86400
... used 10 dbqueries
... used 0.054212808609009 seconds
... used 8.3 MB peak memory
Scheduled task failed: Clean up expired TopoMojo gamespaces (mod_topomojo\task\cleanup_gamespaces),Error reading from database (ERROR:  operator does not exist: character varying = integer
LINE 4:                 AND state IN (20, 30)
                                  ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
SELECT id, topomojoid, userid, eventid, state, timefinish
               FROM mdl_topomojo_attempts
              WHERE eventid IS NOT NULL
                AND state IN (20, 30)
                AND timefinish > 0
                AND timefinish < $1
[array (
  0 => 1780366651,
)])
Debug info:
ERROR:  operator does not exist: character varying = integer
LINE 4:                 AND state IN (20, 30)
                                  ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
SELECT id, topomojoid, userid, eventid, state, timefinish
               FROM mdl_topomojo_attempts
              WHERE eventid IS NOT NULL
                AND state IN (20, 30)
                AND timefinish > 0
                AND timefinish < $1
[array (
  0 => 1780366651,
)]
Backtrace:
* line 346 of /lib/dml/moodle_read_replica_trait.php: call to moodle_database->query_end()
* line 358 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->read_replica_query_end()
* line 1044 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->query_end()
* line 39 of /mod/topomojo/classes/task/cleanup_gamespaces.php: call to pgsql_native_moodle_database->get_records_sql()
* line 411 of /lib/classes/cron.php: call to mod_topomojo\task\cleanup_gamespaces->execute()
* line 208 of /lib/classes/cron.php: call to core\cron::run_inner_scheduled_task()
* line 125 of /lib/classes/cron.php: call to core\cron::run_scheduled_tasks()
* line 186 of /admin/cli/cron.php: call to core\cron::run_main_process()

```
 
 Summary

  - Cast state constants to (string) in the cleanup_gamespaces scheduled task query to fix a PostgreSQL type-mismatch error
  - The previous fix (446c13b, #58) replaced raw IN (20, 30) with get_in_or_equal() but still passed integer constants — PostgreSQL rejects comparing a char(16) column against integer parameters
  - Bump plugin version to 2026060200

  Verification

  The state column on mdl_topomojo_attempts is character varying(16). PostgreSQL does not implicitly cast integers to varchar:

```
  -- BROKEN: integer literals against varchar column (reproduces the reported error)
  SELECT id, state FROM mdl_topomojo_attempts WHERE state IN (20, 30);
  ERROR:  operator does not exist: character varying = integer
  HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

```
  -- FIXED: string literals against varchar column
  SELECT id, state FROM mdl_topomojo_attempts WHERE state IN ('20', '30');
   id | state
  ----+-------
    2 | 30
  (1 row)
```