### PR TITLE
Fix state constants to match schema and follow core quiz pattern

### DIFF
--- a/classes/local/bulkdeploy/management_repository.php
+++ b/classes/local/bulkdeploy/management_repository.php
@@ -263,13 +263,12 @@ class management_repository {
         }
 
         $actionhtml = '─';
-        $attemptstateint = $attemptstate !== null ? (int) $attemptstate : null;
         if (!empty($attemptid) && $hasquestions) {
-            if ($attemptstateint === 10) {
+            if ($attemptstate === \mod_topomojo\topomojo_attempt::INPROGRESS) {
                 $url = new \moodle_url('/mod/topomojo/challenge.php', ['attemptid' => $attemptid]);
                 $actionhtml = \html_writer::link($url, get_string('viewattempt', 'mod_topomojo'),
                     ['class' => 'btn btn-sm btn-outline-primary', 'target' => '_blank']);
-            } else if (in_array($attemptstateint, [20, 30], true)) {
+            } else if (in_array($attemptstate, [\mod_topomojo\topomojo_attempt::ABANDONED, \mod_topomojo\topomojo_attempt::FINISHED], true)) {
                 $url = new \moodle_url('/mod/topomojo/viewattempt.php', ['a' => $attemptid, 'action' => 'view']);
                 $actionhtml = \html_writer::link($url, get_string('viewattempt', 'mod_topomojo'),
                     ['class' => 'btn btn-sm btn-outline-secondary', 'target' => '_blank']);

--- a/classes/topomojo_attempt.php
+++ b/classes/topomojo_attempt.php
@@ -52,17 +52,17 @@ class topomojo_attempt {
 
     /** Constants for the status of the attempt */
 
-    /** @var int NOTSTARTED Indicates that the attempt has not started */
-    const NOTSTARTED = 0;
+    /** @var string NOTSTARTED Indicates that the attempt has not started */
+    const NOTSTARTED = 'notstarted';
 
-    /** @var int INPROGRESS Indicates that the attempt is currently in progress */
-    const INPROGRESS = 10;
+    /** @var string INPROGRESS Indicates that the attempt is currently in progress */
+    const INPROGRESS = 'inprogress';
 
-    /** @var int ABANDONED Indicates that the attempt has been abandoned */
-    const ABANDONED = 20;
+    /** @var string ABANDONED Indicates that the attempt has been abandoned */
+    const ABANDONED = 'abandoned';
 
-    /** @var int FINISHED Indicates that the attempt has finished */
-    const FINISHED = 30;
+    /** @var string FINISHED Indicates that the attempt has finished */
+    const FINISHED = 'finished';
 
     /** @var \stdClass The attempt record */
     protected $attempt;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -625,5 +625,17 @@ function xmldb_topomojo_upgrade($oldversion)
         upgrade_mod_savepoint(true, 2026051504, 'topomojo');
     }
 
+    if ($oldversion < 2026060200) {
+        // Migrate state column from numeric values to string values to match core quiz pattern.
+        // Old: 0='notstarted', 10='inprogress', 20='abandoned', 30='finished'
+        // New: 'notstarted', 'inprogress', 'abandoned', 'finished'
+        $DB->execute("UPDATE {topomojo_attempts} SET state = 'notstarted' WHERE state = '0'");
+        $DB->execute("UPDATE {topomojo_attempts} SET state = 'inprogress' WHERE state = '10'");
+        $DB->execute("UPDATE {topomojo_attempts} SET state = 'abandoned' WHERE state = '20'");
+        $DB->execute("UPDATE {topomojo_attempts} SET state = 'finished' WHERE state = '30'");
+
+        upgrade_mod_savepoint(true, 2026060200, 'topomojo');
+    }
+
     return true;
 }

--- a/manage_action.php
+++ b/manage_action.php
@@ -186,12 +186,12 @@ switch ($action) {
             $attempt = $DB->get_record('topomojo_attempts', [
                 'topomojoid' => $topomojo->id,
                 'userid' => $uid,
-                'state' => 10, // INPROGRESS
+                'state' => \mod_topomojo\topomojo_attempt::INPROGRESS,
             ], '*', IGNORE_MULTIPLE);
 
             if ($attempt && !empty($attempt->eventid)) {
                 stop_event($auth, $attempt->eventid);
-                $attempt->state = 30; // FINISHED
+                $attempt->state = \mod_topomojo\topomojo_attempt::FINISHED;
                 $attempt->timefinish = time();
                 $attempt->timemodified = time();
                 $DB->update_record('topomojo_attempts', $attempt);

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -337,7 +337,7 @@ class lib_test extends \advanced_testcase {
         $attempt = new \stdClass();
         $attempt->topomojoid = $topomojo->id;
         $attempt->userid = $user->id;
-        $attempt->state = 30; // FINISHED
+        $attempt->state = \mod_topomojo\topomojo_attempt::FINISHED;
         $attempt->timestart = time();
         $attempt->timefinish = time();
         $attempt->timemodified = time();

--- a/tests/local/bulkdeploy/management_repository_format_state_test.php
+++ b/tests/local/bulkdeploy/management_repository_format_state_test.php
@@ -66,7 +66,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 99,
-            'attemptstate' => '10',
+            'attemptstate' => 'inprogress',
             'attemptgamespaceid' => 'gs-attempt',
             'attempttimestart' => time() - 100,
             'attemptendtime' => time() + 100,
@@ -89,7 +89,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 99,
-            'attemptstate' => '10',
+            'attemptstate' => 'inprogress',
             'attemptgamespaceid' => 'gs-attempt',
             'attempttimestart' => null,
             'attemptendtime' => null,
@@ -113,7 +113,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 7,
-            'attemptstate' => '10',
+            'attemptstate' => 'inprogress',
             'attemptgamespaceid' => 'gs-attempt',
             'attempttimestart' => $start,
             'attemptendtime' => $end,
@@ -141,7 +141,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 7,
-            'attemptstate' => '30',
+            'attemptstate' => 'finished',
             'attemptgamespaceid' => 'gs',
             'attempttimestart' => null,
             'attemptendtime' => null,
@@ -166,7 +166,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 7,
-            'attemptstate' => '30',
+            'attemptstate' => 'finished',
             'attemptgamespaceid' => 'gs',
             'attempttimestart' => $start,
             'attemptendtime' => $end,
@@ -267,7 +267,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 42,
-            'attemptstate' => '10',
+            'attemptstate' => 'inprogress',
             'attemptgamespaceid' => null,
             'attempttimestart' => null,
             'attemptendtime' => null,
@@ -290,7 +290,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 42,
-            'attemptstate' => '30',
+            'attemptstate' => 'finished',
             'attemptgamespaceid' => null,
             'attempttimestart' => null,
             'attemptendtime' => null,
@@ -313,7 +313,7 @@ final class management_repository_format_state_test extends \advanced_testcase {
         $row = (object) [
             'userid' => 1,
             'attemptid' => 42,
-            'attemptstate' => '10',
+            'attemptstate' => 'inprogress',
             'attemptgamespaceid' => null,
             'attempttimestart' => null,
             'attemptendtime' => null,

--- a/tests/topomojo_attempt_test.php
+++ b/tests/topomojo_attempt_test.php
@@ -60,10 +60,10 @@ class topomojo_attempt_test extends \advanced_testcase {
      * Test attempt class constants.
      */
     public function test_attempt_constants() {
-        $this->assertEquals(0, topomojo_attempt::NOTSTARTED);
-        $this->assertEquals(10, topomojo_attempt::INPROGRESS);
-        $this->assertEquals(20, topomojo_attempt::ABANDONED);
-        $this->assertEquals(30, topomojo_attempt::FINISHED);
+        $this->assertEquals('notstarted', topomojo_attempt::NOTSTARTED);
+        $this->assertEquals('inprogress', topomojo_attempt::INPROGRESS);
+        $this->assertEquals('abandoned', topomojo_attempt::ABANDONED);
+        $this->assertEquals('finished', topomojo_attempt::FINISHED);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026052901;
+$plugin->version = 2026060200;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;

--- a/view.php
+++ b/view.php
@@ -211,7 +211,7 @@ if (!$activeattempt) {
                 'topomojoid' => $topomojo->id,
                 'userid' => $USER->id,
                 'eventid' => $bulkdeployrow->gamespaceid,
-                'state' => 10 // INPROGRESS
+                'state' => \mod_topomojo\topomojo_attempt::INPROGRESS
             ]
         );
 
@@ -282,7 +282,7 @@ if ($challenge && isset($challenge->variants[$variant])) {
 $current_attempt_count = $DB->count_records('topomojo_attempts', [
     'topomojoid' => $topomojo->id,
     'userid' => $userid,
-    'state' => 30,
+    'state' => \mod_topomojo\topomojo_attempt::FINISHED,
     'preview' => 0
 ]);
 
@@ -418,7 +418,7 @@ if ($object->event) {
         $activeattempt = $object->init_attempt($ispreview);
     }
     // Check age and get new link, checking for 30 minute timeout of the url
-    if (($object->openAttempt->state == 10) &&
+    if (($object->openAttempt->state == \mod_topomojo\topomojo_attempt::INPROGRESS) &&
         ((time() - $object->openAttempt->timemodified) > 3600)
     ) {
         debugging("getting new launchpointurl", DEBUG_DEVELOPER);


### PR DESCRIPTION
Changes state constants from integers to strings to properly match the char(16) state column in the database schema. This follows the pattern used by core mod/quiz rather than mod/activequiz.

The mismatch was causing PostgreSQL type errors when using get_in_or_equal() because PostgreSQL strictly enforces type matching and does not implicitly cast integers to varchar in IN clauses.

Changes:
- Change constants from integers (0, 10, 20, 30) to strings ('notstarted', 'inprogress', 'abandoned', 'finished') matching core quiz pattern
- Add upgrade migration to convert existing numeric state values to strings
- Replace all hardcoded numeric state values throughout codebase with constants
- Update test fixtures and assertions to use new string values
- Bump version to 2026060200

This is the proper fix for the issue addressed in PR #58 and PR #64. The schema was always char(16) with DEFAULT='inprogress' but the code incorrectly used numeric constants copied from mod/activequiz (which uses TYPE="int" for its status column).