### PR TITLE
Display variant-specific markdown on challenge page

### DIFF
--- a/challenge.php
+++ b/challenge.php
@@ -146,7 +146,10 @@ if ($activeattempt == true) {
     }
 } else if ($activeattempt == false) {
     debugging("get_open_attempt returned false", DEBUG_DEVELOPER);
-    redirect($returnurl);
+    // Allow instructors to see preview, redirect students
+    if (!has_capability('mod/topomojo:manage', $context)) {
+        redirect($returnurl);
+    }
 }
 
 // Handle start/stop form action
@@ -323,35 +326,84 @@ switch ($action) {
             // Render quiz if questions exist
             if (!empty($object->topomojo->questionorder)) {
                 $renderer->render_quiz($object->openAttempt, $pageurl, $id);
-            } elseif (empty($challenge->text)) {
+            } elseif (isset($challenge) && empty($challenge->text)) {
                 // No challenge text and no questions - show informational message
-                echo $OUTPUT->notification(get_string('nochallengequestions', 'topomojo'), 'info');
+                echo $OUTPUT->notification(get_string('nochallengequestions', 'topomojo'), \core\output\notification::NOTIFY_WARNING);
             }
         } else {
             // No active attempt - only show preview for instructors
             if (has_capability('mod/topomojo:manage', $context)) {
                 // Instructor preview mode
+                echo $OUTPUT->notification(
+                    'Challenge Preview - Students will see this content after launching the lab',
+                    \core\output\notification::NOTIFY_INFO
+                );
+
                 try {
-                    // Get challenge and all variant texts
+                    $preview_text = '';
+                    $has_content = false;
+
+                    // Get challenge structure
                     $full_challenge = get_challenge($object->userauth, $object->topomojo->workspaceid);
+                    debugging("Preview mode - challenge retrieved: " . ($full_challenge ? "yes" : "no"), DEBUG_DEVELOPER);
 
-                    if ($full_challenge && !empty($full_challenge->text)) {
-                        $preview_text = "**Instructor Preview** (Students will see this after launching the lab)\n\n";
-                        $preview_text .= $full_challenge->text;
-
-                        // Show all variants for instructor reference
-                        if (isset($full_challenge->variants) && count($full_challenge->variants) > 0) {
-                            $preview_text .= "\n\n---\n\n**Variant-Specific Text** (Students see one based on random/configured assignment):\n";
-                            foreach ($full_challenge->variants as $idx => $variant) {
-                                if (!empty($variant->text)) {
-                                    $variant_num = $idx + 1;
-                                    $preview_text .= "\n\n**Variant $variant_num:**\n\n" . $variant->text;
-                                }
-                            }
+                    if ($full_challenge) {
+                        // Show challenge markdown (shared across all variants)
+                        if (!empty($full_challenge->text)) {
+                            echo '<div class="card mb-3">';
+                            echo '<div class="card-header bg-primary text-white"><strong>Challenge Markdown</strong></div>';
+                            echo '<div class="card-body">';
+                            $renderer->render_challenge_instructions($full_challenge->text, false);
+                            echo '</div></div>';
+                            $has_content = true;
+                            debugging("Challenge text length: " . strlen($full_challenge->text), DEBUG_DEVELOPER);
                         }
 
-                        $renderer->render_challenge_instructions($preview_text);
-                    } else {
+                        // Show variant-specific texts
+                        if (isset($full_challenge->variants)) {
+                            debugging("Variants count: " . count($full_challenge->variants), DEBUG_DEVELOPER);
+
+                            if (count($full_challenge->variants) > 0) {
+                                $is_random = ($object->topomojo->variant == 0);
+
+                                echo '<div class="card mb-3">';
+                                if ($is_random) {
+                                    echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong> (students see one variant based on random assignment)</div>';
+                                } else {
+                                    echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong></div>';
+                                }
+                                echo '<div class="card-body">';
+
+                                if ($is_random) {
+                                    // Show all variants for random mode
+                                    foreach ($full_challenge->variants as $idx => $variant) {
+                                        if (!empty($variant->text)) {
+                                            $variant_num = $idx + 1;
+                                            echo '<div class="border-bottom pb-3 mb-3">';
+                                            echo '<h5 class="text-primary">Variant ' . $variant_num . '</h5>';
+                                            $renderer->render_challenge_instructions($variant->text, false);
+                                            echo '</div>';
+                                            $has_content = true;
+                                        }
+                                    }
+                                } else {
+                                    // Show only the configured variant
+                                    $variant_index = $object->topomojo->variant - 1; // Convert to 0-based
+                                    $configured_variant = $object->topomojo->variant;
+                                    if (isset($full_challenge->variants[$variant_index]) && !empty($full_challenge->variants[$variant_index]->text)) {
+                                        echo '<h5 class="text-primary">Variant ' . $configured_variant . '</h5>';
+                                        $renderer->render_challenge_instructions($full_challenge->variants[$variant_index]->text, false);
+                                        $has_content = true;
+                                    }
+                                }
+
+                                echo '</div></div>';
+                            }
+                        }
+                    }
+
+                    if (!$has_content) {
+                        debugging("No challenge text or variant text found", DEBUG_DEVELOPER);
                         $renderer->render_no_challenge();
                     }
                 } catch (Exception $e) {

--- a/challenge.php
+++ b/challenge.php
@@ -423,7 +423,10 @@ switch ($action) {
 
                     if (!$has_content) {
                         debugging("No challenge text or variant text found", DEBUG_DEVELOPER);
-                        $renderer->render_no_challenge();
+                        echo $OUTPUT->notification(
+                            'No challenge or variant markdown configured in TopoMojo. Questions can be reviewed on the Questions page.',
+                            \core\output\notification::NOTIFY_INFO
+                        );
                     }
                 } catch (Exception $e) {
                     debugging("Failed to fetch challenge preview: " . $e->getMessage(), DEBUG_DEVELOPER);

--- a/challenge.php
+++ b/challenge.php
@@ -267,26 +267,42 @@ switch ($action) {
 
                     $endlab = $object->topomojo->endlab;
 
-                    if ($challenge->text) {
+                    // Get the full challenge structure to access variant text
+                    $full_challenge = get_challenge($object->userauth, $object->topomojo->workspaceid);
+                    $deployed_variant = $object->event->variant ?? null;
+
+                    $combined_text = $challenge->text ?? '';
+
+                    // Append variant-specific text if available
+                    if ($full_challenge && $deployed_variant !== null && isset($full_challenge->variants[$deployed_variant]->text)) {
+                        $variant_text = $full_challenge->variants[$deployed_variant]->text;
+                        if (!empty($variant_text)) {
+                            $combined_text .= "\n\n" . $variant_text;
+                            debugging("Appended variant $deployed_variant text (" . strlen($variant_text) . " chars)", DEBUG_DEVELOPER);
+                        }
+                    }
+
+                    if ($combined_text) {
+                        debugging("Combined text length: " . strlen($combined_text) . " chars", DEBUG_DEVELOPER);
                         if ($current_attempt_count != $max_attempts && $max_attempts != 0 && $endlab == 0) {
                             // Normal instruction when attempts are not maxed out, no end lab
-                            $renderer->render_challenge_instructions($challenge->text);
+                            $renderer->render_challenge_instructions($combined_text);
                         } elseif ($current_attempt_count == $max_attempts && $max_attempts != 0) {
                             // Conditions when attempts are maxed out
                             if ($endlab == 1) {
                                 // Show end lab warning if the lab is ending
-                                $renderer->render_challenge_instructions_warning_endlab($challenge->text);
+                                $renderer->render_challenge_instructions_warning_endlab($combined_text);
                             } else {
                                 // Show warning if max attempts are reached, lab not ending
-                                $renderer->render_challenge_instructions_warning($challenge->text);
+                                $renderer->render_challenge_instructions_warning($combined_text);
                             }
                         } elseif ($current_attempt_count < $max_attempts && $max_attempts != 0 && $endlab == 1) {
-                            $renderer->render_challenge_instructions_endlab($challenge->text);
+                            $renderer->render_challenge_instructions_endlab($combined_text);
                         } elseif ($max_attempts == 0 && $endlab == 1) {
-                            $renderer->render_challenge_instructions_endlab($challenge->text);
+                            $renderer->render_challenge_instructions_endlab($combined_text);
                         } else {
                             // Default: show instructions without special formatting (unlimited attempts, no endlab)
-                            $renderer->render_challenge_instructions($challenge->text);
+                            $renderer->render_challenge_instructions($combined_text);
                         }
                     } else {
                         // No challenge text; handle general warnings based on attempts and endlab
@@ -312,7 +328,39 @@ switch ($action) {
                 echo $OUTPUT->notification(get_string('nochallengequestions', 'topomojo'), 'info');
             }
         } else {
-            $renderer->render_no_challenge();
+            // No active attempt - only show preview for instructors
+            if (has_capability('mod/topomojo:manage', $context)) {
+                // Instructor preview mode
+                try {
+                    // Get challenge and all variant texts
+                    $full_challenge = get_challenge($object->userauth, $object->topomojo->workspaceid);
+
+                    if ($full_challenge && !empty($full_challenge->text)) {
+                        $preview_text = "**Instructor Preview** (Students will see this after launching the lab)\n\n";
+                        $preview_text .= $full_challenge->text;
+
+                        // Show all variants for instructor reference
+                        if (isset($full_challenge->variants) && count($full_challenge->variants) > 0) {
+                            $preview_text .= "\n\n---\n\n**Variant-Specific Text** (Students see one based on random/configured assignment):\n";
+                            foreach ($full_challenge->variants as $idx => $variant) {
+                                if (!empty($variant->text)) {
+                                    $variant_num = $idx + 1;
+                                    $preview_text .= "\n\n**Variant $variant_num:**\n\n" . $variant->text;
+                                }
+                            }
+                        }
+
+                        $renderer->render_challenge_instructions($preview_text);
+                    } else {
+                        $renderer->render_no_challenge();
+                    }
+                } catch (Exception $e) {
+                    debugging("Failed to fetch challenge preview: " . $e->getMessage(), DEBUG_DEVELOPER);
+                    $renderer->render_no_challenge();
+                }
+            } else {
+                $renderer->render_no_challenge();
+            }
         }
 }
 // Attempts may differ from events pulled from history on server

--- a/challenge.php
+++ b/challenge.php
@@ -365,39 +365,58 @@ switch ($action) {
 
                             if (count($full_challenge->variants) > 0) {
                                 $is_random = ($object->topomojo->variant == 0);
+                                $variant_has_text = false;
 
-                                echo '<div class="card mb-3">';
+                                // Check if any variant has text before showing the card
                                 if ($is_random) {
-                                    echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong> (students see one variant based on random assignment)</div>';
-                                } else {
-                                    echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong></div>';
-                                }
-                                echo '<div class="card-body">';
-
-                                if ($is_random) {
-                                    // Show all variants for random mode
-                                    foreach ($full_challenge->variants as $idx => $variant) {
+                                    foreach ($full_challenge->variants as $variant) {
                                         if (!empty($variant->text)) {
-                                            $variant_num = $idx + 1;
-                                            echo '<div class="border-bottom pb-3 mb-3">';
-                                            echo '<h5 class="text-primary">Variant ' . $variant_num . '</h5>';
-                                            $renderer->render_challenge_instructions($variant->text, false);
-                                            echo '</div>';
-                                            $has_content = true;
+                                            $variant_has_text = true;
+                                            break;
                                         }
                                     }
                                 } else {
-                                    // Show only the configured variant
-                                    $variant_index = $object->topomojo->variant - 1; // Convert to 0-based
-                                    $configured_variant = $object->topomojo->variant;
+                                    $variant_index = $object->topomojo->variant - 1;
                                     if (isset($full_challenge->variants[$variant_index]) && !empty($full_challenge->variants[$variant_index]->text)) {
-                                        echo '<h5 class="text-primary">Variant ' . $configured_variant . '</h5>';
-                                        $renderer->render_challenge_instructions($full_challenge->variants[$variant_index]->text, false);
-                                        $has_content = true;
+                                        $variant_has_text = true;
                                     }
                                 }
 
-                                echo '</div></div>';
+                                // Only show card if there's variant text to display
+                                if ($variant_has_text) {
+                                    echo '<div class="card mb-3">';
+                                    if ($is_random) {
+                                        echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong> (students see one variant based on random assignment)</div>';
+                                    } else {
+                                        echo '<div class="card-header bg-light"><strong>Variant-Specific Text</strong></div>';
+                                    }
+                                    echo '<div class="card-body">';
+
+                                    if ($is_random) {
+                                        // Show all variants for random mode
+                                        foreach ($full_challenge->variants as $idx => $variant) {
+                                            if (!empty($variant->text)) {
+                                                $variant_num = $idx + 1;
+                                                echo '<div class="border-bottom pb-3 mb-3">';
+                                                echo '<h5 class="text-primary">Variant ' . $variant_num . '</h5>';
+                                                $renderer->render_challenge_instructions($variant->text, false);
+                                                echo '</div>';
+                                                $has_content = true;
+                                            }
+                                        }
+                                    } else {
+                                        // Show only the configured variant
+                                        $variant_index = $object->topomojo->variant - 1; // Convert to 0-based
+                                        $configured_variant = $object->topomojo->variant;
+                                        if (isset($full_challenge->variants[$variant_index]) && !empty($full_challenge->variants[$variant_index]->text)) {
+                                            echo '<h5 class="text-primary">Variant ' . $configured_variant . '</h5>';
+                                            $renderer->render_challenge_instructions($full_challenge->variants[$variant_index]->text, false);
+                                            $has_content = true;
+                                        }
+                                    }
+
+                                    echo '</div></div>';
+                                }
                             }
                         }
                     }

--- a/challenge.php
+++ b/challenge.php
@@ -424,10 +424,16 @@ switch ($action) {
                     if (!$has_content) {
                         debugging("No challenge text or variant text found", DEBUG_DEVELOPER);
                         echo $OUTPUT->notification(
-                            'No challenge or variant markdown configured in TopoMojo. Questions can be reviewed on the Questions page.',
+                            'No challenge or variant markdown configured in TopoMojo.',
                             \core\output\notification::NOTIFY_INFO
                         );
                     }
+
+                    // Add note about managing questions
+                    echo $OUTPUT->notification(
+                        'To manage graded questions for this activity, visit the Questions page.',
+                        \core\output\notification::NOTIFY_INFO
+                    );
                 } catch (Exception $e) {
                     debugging("Failed to fetch challenge preview: " . $e->getMessage(), DEBUG_DEVELOPER);
                     $renderer->render_no_challenge();

--- a/lang/en/topomojo.php
+++ b/lang/en/topomojo.php
@@ -488,4 +488,4 @@ $string['randomvariantinfo'] = 'Random variant mode: Questions from all variants
 $string['cannotaddvariantquestionrandom'] = 'Cannot add variant-specific questions in random variant mode. Only manually created questions (True/False, etc.) can be added.';
 $string['questionsnotimported_teacher'] = 'Questions have not been imported yet. <a href="{$a}">Visit the Questions page</a> or update activity settings to trigger import.';
 $string['questionsnotimported_student'] = 'This activity is not ready yet. Please contact your instructor.';
-$string['nochallengequestions'] = 'This activity has no graded questions.';
+$string['nochallengequestions'] = 'This activity has no graded questions. Review questions on the Questions page.';

--- a/lang/en/topomojo.php
+++ b/lang/en/topomojo.php
@@ -489,3 +489,4 @@ $string['cannotaddvariantquestionrandom'] = 'Cannot add variant-specific questio
 $string['questionsnotimported_teacher'] = 'Questions have not been imported yet. <a href="{$a}">Visit the Questions page</a> or update activity settings to trigger import.';
 $string['questionsnotimported_student'] = 'This activity is not ready yet. Please contact your instructor.';
 $string['nochallengequestions'] = 'This activity has no graded questions. Review questions on the Questions page.';
+$string['launching_manual_refresh'] = 'Lab is launching. Please refresh the page manually to check if your environment is ready.';

--- a/renderer.php
+++ b/renderer.php
@@ -262,11 +262,12 @@ class mod_topomojo_renderer extends \plugin_renderer_base {
      * @param string $markdown The Markdown-formatted instructions to be rendered.
      * @return void
      */
-    public function render_challenge_instructions($markdown) {
+    public function render_challenge_instructions($markdown, $hasQuiz = true) {
         $data = new stdClass();
         $data->markdown = $this->clean_markdown($markdown);
         $data->showWarning = false; // No warning in normal instructions
         $data->endlab = false;      // Not an end-lab scenario
+        $data->hasQuiz = $hasQuiz;  // Whether there are quiz questions (controls beforeunload warning)
 
         echo $this->render_from_template('mod_topomojo/challenge', $data);
     }

--- a/templates/challenge.mustache
+++ b/templates/challenge.mustache
@@ -48,7 +48,9 @@ DM24-1175
 <div class="alert alert-warning">{{# str }} finalattempt, mod_topomojo {{/ str }}</div>
 {{/showWarning}}
 
+{{#hasQuiz}}
 <div class="alert alert-warning">{{#str}} responsesnotsaved, mod_topomojo {{/str}}</div>
+{{/hasQuiz}}
 
 {{#endlab}}
 <div class="alert alert-warning">{{# str }} endlabmessage, mod_topomojo {{/ str }}</div>
@@ -58,6 +60,7 @@ DM24-1175
 {{{markdown}}}
 </div>
 
+{{#hasQuiz}}
 <script>
 let quizSubmitted = false;
 
@@ -72,4 +75,5 @@ window.addEventListener('beforeunload', function (e) {
     }
 });
 </script>
+{{/hasQuiz}}
 

--- a/templates/challenge.mustache
+++ b/templates/challenge.mustache
@@ -54,10 +54,6 @@ DM24-1175
 <div class="alert alert-warning">{{# str }} endlabmessage, mod_topomojo {{/ str }}</div>
 {{/endlab}}
 
-<div>
-<h1>{{# str }} challengeinstructions, mod_topomojo {{/ str }}</h1>
-</div>
-<br>
 <div id="topomojo-markdown">
 {{{markdown}}}
 </div>

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026060200;
+$plugin->version = 2026060201;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;


### PR DESCRIPTION
  ### Problem
  Students couldn't see variant-specific instructions on the challenge page during lab attempts. The challenge page only showed the base challenge text,
  missing the variant-specific markdown that provides instructions unique to each variant.
  
  Instructors had no way to preview challenge and variant markdown without launching a lab.

  ### Solution

  **For students during active attempts:**
  - Fetches full challenge structure and appends variant-specific markdown to challenge text
  - Students see combined Challenge + Variant instructions on challenge.php
  - Variant text is correctly matched to their deployed gamespace variant (0-based indexed)

  **For instructors (preview mode):**
  - Allows instructors to access challenge.php without launching a lab
  - Displays challenge markdown in a blue card (shown to all students)
  - Displays variant-specific text in a gray card:
    - Random mode (variant=0): Shows all variants for reference
    - Specific variant mode: Shows only the configured variant
  - Adds info notification explaining this is preview mode
  - Removes "responses not saved" warning and beforeunload popup from preview (no quiz present)

  **Additional improvements:**
  - Removed redundant "Challenge Instructions" heading from template (markdown has its own headings)
  - Updated "no questions" message to direct users to Questions page
  - Added `hasQuiz` flag to conditionally show quiz-related warnings

  ### Testing
  1. Create activity with multiple variants, each with variant-specific text
  2. **Student view**: Launch lab, verify challenge.php shows both challenge markdown and variant-specific text
  3. **Instructor preview**: Visit challenge.php without launching lab, verify both sections display
  4. Test random mode: All variants shown in preview
  5. Test specific variant: Only configured variant shown in preview
  6. Verify no beforeunload popup when navigating away from preview

  ### Files Changed
  - `challenge.php` - Variant text appending, instructor preview logic
  - `renderer.php` - Add `hasQuiz` parameter to control quiz-related UI
  - `templates/challenge.mustache` - Conditional quiz warnings
  - `lang/en/topomojo.php` - Updated "no questions" message