### PR TITLE
Fix gamespace isolation for activities sharing the same workspace

### DIFF
--- a/challenge.php
+++ b/challenge.php
@@ -96,11 +96,11 @@ $pagevars = [];
 $pagevars['pageurl'] = $pageurl;
 $object = new \mod_topomojo\topomojo($cm, $course, $topomojo, $pageurl, $pagevars);
 
-// Get current state of workspace
-$allevents = list_events($object->userauth, $object->topomojo->workspaceid); // events for workspace
-$eventsmoodle = moodle_events($object->userauth, $allevents); // events for moodle bot
-$history = user_events($object->userauth, $eventsmoodle); // events for this user
-$object->event = get_active_event($history);
+// Initialize event as null - will be set from attempt records if user has active gamespace
+// CRITICAL: Do NOT use list_events() fallback here as it returns ALL gamespaces for this workspace,
+// causing cross-contamination when multiple activities share the same workspace.
+// Each activity must only see gamespaces created from its own attempts.
+$object->event = null;
 
 // Check if this is a preview attempt from URL parameter
 $ispreview = $previewparam;

--- a/challenge.php
+++ b/challenge.php
@@ -158,6 +158,23 @@ if ($_SERVER['REQUEST_METHOD'] == "POST" && isset($_POST['start'])) {
 
     // Check not started already
     if (!$object->event) {
+        // Check for conflicting gamespace from another activity sharing this workspace
+        $conflict = check_conflicting_gamespace($topomojo->id, $topomojo->workspaceid);
+        if ($conflict) {
+            $conflicturl = new moodle_url('/mod/topomojo/view.php', ['id' => $conflict->cmid]);
+            $conflictdata = (object)[
+                'activityname' => $conflict->activityname,
+                'activityurl' => $conflicturl->out()
+            ];
+            echo $OUTPUT->header();
+            echo $OUTPUT->notification(
+                get_string('conflicting_gamespace', 'mod_topomojo', $conflictdata),
+                \core\output\notification::NOTIFY_ERROR
+            );
+            echo html_writer::link($conflicturl, get_string('conflicting_gamespace_link', 'mod_topomojo', $conflictdata), ['class' => 'btn btn-secondary']);
+            echo $OUTPUT->footer();
+            exit;
+        }
 
         // TODO check for open attempt and check for status of its event
         $object->event = start_event($object->userauth, $object->topomojo->workspaceid, $object->topomojo);

--- a/classes/local/bulkdeploy/management_repository.php
+++ b/classes/local/bulkdeploy/management_repository.php
@@ -264,14 +264,12 @@ class management_repository {
 
         $actionhtml = '─';
         if (!empty($attemptid) && $hasquestions) {
-            if ($attemptstate === \mod_topomojo\topomojo_attempt::INPROGRESS) {
-                $url = new \moodle_url('/mod/topomojo/challenge.php', ['attemptid' => $attemptid]);
-                $actionhtml = \html_writer::link($url, get_string('viewattempt', 'mod_topomojo'),
-                    ['class' => 'btn btn-sm btn-outline-primary', 'target' => '_blank']);
-            } else if (in_array($attemptstate, [\mod_topomojo\topomojo_attempt::ABANDONED, \mod_topomojo\topomojo_attempt::FINISHED], true)) {
+            // All attempt states link to viewattempt.php for instructor review
+            if (in_array($attemptstate, [\mod_topomojo\topomojo_attempt::INPROGRESS, \mod_topomojo\topomojo_attempt::ABANDONED, \mod_topomojo\topomojo_attempt::FINISHED], true)) {
                 $url = new \moodle_url('/mod/topomojo/viewattempt.php', ['a' => $attemptid, 'action' => 'view']);
+                $buttonclass = $attemptstate === \mod_topomojo\topomojo_attempt::INPROGRESS ? 'btn-outline-primary' : 'btn-outline-secondary';
                 $actionhtml = \html_writer::link($url, get_string('viewattempt', 'mod_topomojo'),
-                    ['class' => 'btn btn-sm btn-outline-secondary', 'target' => '_blank']);
+                    ['class' => 'btn btn-sm ' . $buttonclass, 'target' => '_blank']);
             }
         }
 

--- a/lang/en/topomojo.php
+++ b/lang/en/topomojo.php
@@ -490,3 +490,6 @@ $string['questionsnotimported_teacher'] = 'Questions have not been imported yet.
 $string['questionsnotimported_student'] = 'This activity is not ready yet. Please contact your instructor.';
 $string['nochallengequestions'] = 'This activity has no graded questions. Review questions on the Questions page.';
 $string['launching_manual_refresh'] = 'Lab is launching. Please refresh the page manually to check if your environment is ready.';
+$string['gamespace_not_found'] = 'Your lab session could not be found. It may have expired or been terminated. Please start a new attempt.';
+$string['gamespace_terminated'] = 'Your lab session was terminated. Start a new attempt to continue.';
+$string['attempt_orphaned'] = 'Your attempt record exists but the lab environment is no longer available. Please contact your instructor.';

--- a/lang/en/topomojo.php
+++ b/lang/en/topomojo.php
@@ -493,3 +493,6 @@ $string['launching_manual_refresh'] = 'Lab is launching. Please refresh the page
 $string['gamespace_not_found'] = 'Your lab session could not be found. It may have expired or been terminated. Please start a new attempt.';
 $string['gamespace_terminated'] = 'Your lab session was terminated. Start a new attempt to continue.';
 $string['attempt_orphaned'] = 'Your attempt record exists but the lab environment is no longer available. Please contact your instructor.';
+$string['conflicting_gamespace_title'] = 'Active lab in another activity';
+$string['conflicting_gamespace'] = 'You have an active lab session in <strong>{$a->activityname}</strong> which shares the same workspace. You must end that lab before starting this one.';
+$string['conflicting_gamespace_link'] = 'Go to {$a->activityname}';

--- a/locallib.php
+++ b/locallib.php
@@ -734,6 +734,43 @@ function stop_event($client, $id)
 }
 
 /**
+ * Checks if user has an active gamespace from another activity sharing the same workspace.
+ *
+ * TopoMojo's Register endpoint returns existing active gamespaces for a workspace+user,
+ * ignoring variant differences. When multiple activities share a workspace, we must
+ * detect this conflict before launch to prevent the wrong gamespace being reused.
+ *
+ * @param int $topomojoid Current activity ID
+ * @param string $workspaceid Workspace GUID
+ * @return stdClass|null Conflicting attempt record with activity details, or null if none
+ */
+function check_conflicting_gamespace($topomojoid, $workspaceid) {
+    global $DB, $USER;
+
+    // Find active attempts from OTHER activities using the same workspace
+    $sql = "SELECT ta.*, t.name as activityname, t.course, cm.id as cmid
+            FROM {topomojo_attempts} ta
+            JOIN {topomojo} t ON t.id = ta.topomojoid
+            JOIN {course_modules} cm ON cm.instance = t.id
+            JOIN {modules} m ON m.id = cm.module AND m.name = 'topomojo'
+            WHERE ta.userid = :userid
+              AND ta.state = :state
+              AND ta.topomojoid != :topomojoid
+              AND t.workspaceid = :workspaceid
+            ORDER BY ta.timemodified DESC
+            LIMIT 1";
+
+    $conflict = $DB->get_record_sql($sql, [
+        'userid' => $USER->id,
+        'state' => \mod_topomojo\topomojo_attempt::INPROGRESS,
+        'topomojoid' => $topomojoid,
+        'workspaceid' => $workspaceid
+    ]);
+
+    return $conflict ?: null;
+}
+
+/**
  * Retrieves a ticket from the TopoMojo API for the current user.
  *
  * This function sends a GET request to the TopoMojo API to obtain a ticket associated with the current user.

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026060201;
+$plugin->version = 2026060300;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;

--- a/view.php
+++ b/view.php
@@ -107,11 +107,11 @@ if (!$healthstatus['healthy']) {
     die();
 }
 
-// Get current state of workspace
-$allevents = list_events($object->userauth, $object->topomojo->workspaceid);
-$eventsmoodle = moodle_events($object->userauth, events: $allevents);
-$history = user_events($object->userauth, events: $eventsmoodle);
-$object->event = get_active_event($history);
+// Initialize event as null - will be set from attempt records if user has active gamespace
+// CRITICAL: Do NOT use list_events() fallback here as it returns ALL gamespaces for this workspace,
+// causing cross-contamination when multiple activities share the same workspace.
+// Each activity must only see gamespaces created from its own attempts.
+$object->event = null;
 $renderer = $object->renderer;
 echo $renderer->header();
 

--- a/view.php
+++ b/view.php
@@ -353,6 +353,23 @@ if ($_SERVER['REQUEST_METHOD'] == "POST" && isset($_POST['start_confirmed']) && 
 
     // Check not started already
     if (!$object->event) {
+        // Check for conflicting gamespace from another activity sharing this workspace
+        $conflict = check_conflicting_gamespace($topomojo->id, $topomojo->workspaceid);
+        if ($conflict) {
+            $conflicturl = new moodle_url('/mod/topomojo/view.php', ['id' => $conflict->cmid]);
+            $conflictdata = (object)[
+                'activityname' => $conflict->activityname,
+                'activityurl' => $conflicturl->out()
+            ];
+            echo $OUTPUT->notification(
+                get_string('conflicting_gamespace', 'mod_topomojo', $conflictdata),
+                \core\output\notification::NOTIFY_ERROR
+            );
+            echo html_writer::link($conflicturl, get_string('conflicting_gamespace_link', 'mod_topomojo', $conflictdata), ['class' => 'btn btn-secondary']);
+            echo $renderer->footer();
+            exit;
+        }
+
         // Attempt to start the event
         $object->event = start_event($object->userauth, $object->topomojo->workspaceid, $object->topomojo);
 


### PR DESCRIPTION
  ### Problem

  When multiple Moodle activities share the same TopoMojo workspace (e.g., 10 activities using different variants of the same workspace), two critical
  issues occurred:

  1. **Cross-contamination in UI**: Activities displayed gamespaces from other activities in their history and status views
  2. **Wrong gamespace reused on launch**: When a student launched from Activity B while having an active gamespace from Activity A, TopoMojo's API
  silently returned Activity A's gamespace instead of creating a new one (wrong variant, wrong timer, wrong challenge questions)

  ### Root Cause

  **Moodle side**: The `list_events()` fallback in `view.php` and `challenge.php` queried TopoMojo for ALL active gamespaces matching the workspace ID,
  without filtering by activity (topomojoid). This caused activities to adopt gamespaces created by other activities.

  **TopoMojo side**: The `Register` endpoint checks if a user already has an active gamespace for a workspace and returns it (HTTP 200, no error),
  ignoring variant differences. This is intentional idempotent behavior, but violates Moodle's assumption that each activity is independent.

  ### Solution

  **Commit 1: Fix gamespace isolation**
  - Removed `list_events()` fallback chain in `view.php` and `challenge.php`
  - Activities now only fetch gamespaces from their own attempt records via `get_open_attempt()`
  - Prevents cross-contamination in history and status display

  **Commit 2: Prevent conflicting gamespace launches**
  - Added `check_conflicting_gamespace()` function to detect active gamespace from another activity sharing the same workspace
  - Blocks launch in `view.php` and `challenge.php` with clear error message and link to conflicting activity
  - Prevents TopoMojo from silently returning the wrong gamespace
  - Added language strings for conflict warning

  **Commit 3: Fix manage page viewattempt link**
  - Changed in-progress attempt links to use `viewattempt.php` instead of `challenge.php`
  - Fixes "Can't find data record in database" error when instructors click view attempt link
  - All attempt states now consistently link to viewattempt.php for instructor review

  ### Testing

  **Setup**: Two activities sharing workspace `abc123`
  - Activity A: Random variant mode
  - Activity B: Specific variant 2

  **Test flow**:
  1. Student launches from Activity A → gamespace created (e.g., variant 3)
  2. Student visits Activity B → sees "Launch Lab" (not Activity A's gamespace) ✅
  3. Student clicks "Launch Lab" → blocked with error: "You have an active lab session in Activity A which shares the same workspace. You must end that
  lab before starting this one." ✅
  4. Student returns to Activity A, ends lab
  5. Student returns to Activity B, launches → succeeds with correct variant 2 ✅
  6. Each activity's history shows only its own attempts ✅
  7. Instructor clicks "View Attempt" on manage page → opens correctly ✅

  ### Impact

  - ✅ Multiple activities can safely share the same TopoMojo workspace with proper isolation
  - ✅ Students cannot accidentally get wrong variant/timer/questions
  - ✅ Clear error messages guide users to resolve conflicts
  - ✅ Instructor management pages work correctly
  - ⚠️  Users can only have one active gamespace per workspace at a time (enforced by TopoMojo API)

  ### Files Changed

  - `view.php` - Remove list_events fallback, add conflict check before launch
  - `challenge.php` - Remove list_events fallback, add conflict check before launch
  - `locallib.php` - Add check_conflicting_gamespace() function
  - `lang/en/topomojo.php` - Add conflict warning strings
  - `classes/local/bulkdeploy/management_repository.php` - Fix viewattempt link for in-progress attempts