### PR TITLE
Fix state map in management_repository to use new string constants

### DIFF
--- a/classes/local/bulkdeploy/management_repository.php
+++ b/classes/local/bulkdeploy/management_repository.php
@@ -216,12 +216,12 @@ class management_repository {
             $statuslabel = ucfirst($deploystatus);
         } else if (!empty($attemptid)) {
             $statemap = [
-                '0'  => 'Not Started',
-                '10' => 'Active',
-                '20' => 'Abandoned',
-                '30' => 'Finished',
+                'notstarted' => 'Not Started',
+                'inprogress' => 'Active',
+                'abandoned'  => 'Abandoned',
+                'finished'   => 'Finished',
             ];
-            $statuslabel = $statemap[(string) $attemptstate] ?? (string) ($attemptstate ?? 'unknown');
+            $statuslabel = $statemap[$attemptstate] ?? (string) ($attemptstate ?? 'unknown');
         } else if (!empty($deploystatus)) {
             $statuslabel = ucfirst($deploystatus);
         }

--- a/version.php
+++ b/version.php
@@ -46,7 +46,7 @@ DM24-1175
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026060300;
+$plugin->version = 2026060301;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;


### PR DESCRIPTION
Updates the state-to-label mapping to use the new string state values ('notstarted', 'inprogress', 'abandoned', 'finished') instead of the old numeric strings ('0', '10', '20', '30').

This was missed in PR #65 which changed the state constants from integers to strings. Without this fix, the bulk deployment management page shows 'unknown' status for all attempts instead of the correct labels.

Fixes display of attempt status in manage deployments table.